### PR TITLE
加速度センサーを識別する機能を追加

### DIFF
--- a/src/vm/extensions/block/adxl345.js
+++ b/src/vm/extensions/block/adxl345.js
@@ -56,7 +56,7 @@ export default class ADXL345 {
      * @param {AkadakoBoard} board - connecting akadako board
      * @returns {Promise<boolean>} A Promise which resolves true if the device is ADXL345, false otherwise.
      */
-    static async isConnected(board) {
+    static async isConnected (board) {
         try {
             const adxl345 = new ADXL345(board);
             await adxl345.readID();

--- a/src/vm/extensions/block/adxl345.js
+++ b/src/vm/extensions/block/adxl345.js
@@ -51,6 +51,22 @@ export default class ADXL345 {
     }
 
     /**
+     * Check if the connected device is ADXL345.
+     *
+     * @param {AkadakoBoard} board - connecting akadako board
+     * @returns {Promise<boolean>} A Promise which resolves true if the device is ADXL345, false otherwise.
+     */
+    static async isConnected(board) {
+        try {
+            const adxl345 = new ADXL345(board);
+            await adxl345.readID();
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    /**
      * Initialize the sensor
      * @returns {Promise} a Promise which resolves when the sensor was initialized
      */

--- a/src/vm/extensions/block/index.js
+++ b/src/vm/extensions/block/index.js
@@ -1227,11 +1227,16 @@ class ExtensionBlocks {
     async getAccelerometer () {
         if (!this.accelerometer) {
             let newSensor = null;
-            if (this.board.version.type === 2) {
-                // STEAM Tool
+            const isKXTJ3Connected = await KXTJ3.isConnected(this.board);
+            if (isKXTJ3Connected) {
                 newSensor = new KXTJ3(this.board);
             } else {
-                newSensor = new ADXL345(this.board);
+                const isADXL345Connected = await ADXL345.isConnected(this.board);
+                if (isADXL345Connected) {
+                    newSensor = new ADXL345(this.board);
+                } else {
+                    throw new Error('No supported accelerometer found');
+                }
             }
             await newSensor.init();
             this.accelerometer = newSensor;

--- a/src/vm/extensions/block/kxtj3.js
+++ b/src/vm/extensions/block/kxtj3.js
@@ -77,6 +77,22 @@ export default class KXTJ3 {
     }
 
     /**
+     * Check if the connected device is KXTJ3.
+     *
+     * @param {AkadakoBoard} board - connecting akadako board
+     * @returns {Promise<boolean>} A Promise which resolves true if the device is KXTJ3, false otherwise.
+     */
+    static async isConnected(board) {
+        try {
+            const kxtj3 = new KXTJ3(board);
+            await kxtj3.initDevice();
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    /**
      * Initialize the device.
      *
      * @param {number} range Range of gravity sensing. [ 2 | 4 | 8 | 16 ]

--- a/src/vm/extensions/block/kxtj3.js
+++ b/src/vm/extensions/block/kxtj3.js
@@ -82,7 +82,7 @@ export default class KXTJ3 {
      * @param {AkadakoBoard} board - connecting akadako board
      * @returns {Promise<boolean>} A Promise which resolves true if the device is KXTJ3, false otherwise.
      */
-    static async isConnected(board) {
+    static async isConnected (board) {
         try {
             const kxtj3 = new KXTJ3(board);
             await kxtj3.initDevice();


### PR DESCRIPTION
ADXL345とKXTJ3-1057のどちらが接続されているか識別して加速度の値を取得するように修正しました。
それにより、AkaDakoやAkaDako2でも、ADXL345以外に、今後販売予定のKXTJ3-1057ボードを接続した際、加速度のブロックが使えるようになります。