### PR TITLE
Revert "AkaDakoを接続中でなくても通信系ブロックを使えるようにした"

### DIFF
--- a/src/vm/extensions/block/index.js
+++ b/src/vm/extensions/block/index.js
@@ -2188,6 +2188,7 @@ class ExtensionBlocks {
      * @return {?Promise<string>} a Promise that resolves when connected or undefined if this process was yield.
      */
     connectToShareServer (args, util) {
+        if (!this.isConnected()) return Promise.resolve('AkaDako was not connected');
         if (this.shareServerGetting) {
             util.yield(); // re-try this call after a while.
             return; // Do not return Promise to re-try.
@@ -2217,6 +2218,7 @@ class ExtensionBlocks {
      * @return {?Promise} a Promise that resolves when sending done or undefined if this process was yield.
      */
     sendSharedData (args, util) {
+        if (!this.isConnected()) return Promise.resolve('AkaDako was not connected');
         if (this.dataSharingWasCanceled) return Promise.resolve('Data sharing was canceled by user.');
         if (!this.isShareServerConnected()) return Promise.resolve('Share server was not connected.');
         if (this.shareDataSending || this.shareServerGetting) {
@@ -2295,6 +2297,7 @@ class ExtensionBlocks {
      * @return {boolean} - true if the data received.
      */
     whenSharedDataReceived (args) {
+        if (!this.isConnected()) return false;
         if (!this.isShareServerConnected()) return false;
         if (!this.updateLastSharedDataTimer) {
             this.updateLastSharedDataTimer = setTimeout(() => {


### PR DESCRIPTION
This reverts commit 8e0d08c9b23a5ab6c7e27a807e31f3e79bac7066.