### PR TITLE
通信機能のパフォーマンス最適化とバグ修正

### DIFF
--- a/src/vm/extensions/block/index.js
+++ b/src/vm/extensions/block/index.js
@@ -2006,6 +2006,7 @@ class ExtensionBlocks {
         this.shareDataSending = false;
         this.sharedData = {};
         this.prevSharedData = {};
+        this.labelTimestamps = {};
         this.shareServerBackoffAttempt = 0;
         if (this.shareServer) {
             const server = this.shareServer;


### PR DESCRIPTION
## Summary
- `whenSharedDataReceived`メソッドをラベル単位でのタイムスタンプ管理に変更し、通信機能のパフォーマンスを最適化
- `resetShareServer`で`labelTimestamps`をリセットするように修正し、サーバー再接続時にデータ受信を見逃すバグを解消

## Test plan
- [ ] 通信機能（データ共有）が正常に動作すること
- [ ] サーバー再接続後にデータ受信が正しく行われること
- [ ] ラベル単位でのタイムスタンプ管理が意図通りに機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)